### PR TITLE
Fix/bug in create endpoint

### DIFF
--- a/app/main/model/review.py
+++ b/app/main/model/review.py
@@ -67,25 +67,24 @@ class Review(db.Model):
         return None
 
     def create_review(self, data):
-        self.public_id = str(uuid.uuid4())
-        self.title = data.get("title")
-        self.content = data.get("content")
-        self.location = data.get("location")
-        if not self.title or not self.content:
-            return None
-        
-        region_id = data.get("region_id")
         region_model = Region()
-        self.region_id = region_model.get_region_by_id(region_id)
+        region_id = data.get("region_id")
 
-        self.created_at = datetime.datetime.utcnow()
-        self.updated_at = datetime.datetime.utcnow()
-        self.upvotes = 0
-        self.downvotes = 0
-        self.visible = True
+        review = Review(
+            public_id = str(uuid.uuid4()),
+            title = data.get("title"),
+            content = data.get("content"),
+            location = data.get("location"),
+            region_id = region_model.get_region_by_id(region_id),
+            created_at = datetime.datetime.utcnow(),
+            updated_at = datetime.datetime.utcnow(),
+            upvotes = 0,
+            downvotes = 0,
+            visible = True,
+        )
 
-        self.save()
-        return self.serialize()
+        review.save()
+        return review.serialize()
 
     def update_review(self, public_id, data):
         review = self.query.filter_by(public_id=public_id, visible=True).first()

--- a/app/main/model/user.py
+++ b/app/main/model/user.py
@@ -67,20 +67,23 @@ class User(db.Model):
             email = data.get("email")
             if not is_valid_email(email):
                 raise Exception("The email is invalid")
-            user = self.query.filter_by(email=email).first()
-            if user:
+            registered_user = self.query.filter_by(email=email).first()
+            if registered_user:
                 raise Exception("This email has already registered")
 
-            self.public_id = str(uuid.uuid4())
-            self.username = data.get("username")
-            self.email = email
-            self.password = password
-            self.role = data.get("role", "user")
-            self.status = data.get("status", "active")
-            self.created_at = datetime.datetime.utcnow()
-            self.updated_at = datetime.datetime.utcnow()
-            self.save()
-            return self.serialize()
+            user = User(
+                public_id = str(uuid.uuid4()),
+                username = data.get("username"),
+                email = email,
+                password = password,
+                role = data.get("role", "user"),
+                status = data.get("status", "active"),
+                created_at = datetime.datetime.utcnow(),
+                updated_at = datetime.datetime.utcnow(),
+            )
+
+            user.save()
+            return user.serialize()
         except Exception as e:
             raise e
 
@@ -91,20 +94,23 @@ class User(db.Model):
             email = data.get("email")
             if not is_valid_email(email):
                 raise Exception("The email is invalid")
-            user = self.query.filter_by(email=email).first()
-            if user:
+            registered_user = self.query.filter_by(email=email).first()
+            if registered_user:
                 raise Exception("This email has already registered")
+            
+            user = User(
+                public_id = str(uuid.uuid4()),
+                username = data.get("username"),
+                email = email,
+                password = password,
+                role = data.get("role", "admin"),
+                status = data.get("status", "active"),
+                created_at = datetime.datetime.utcnow(),
+                updated_at = datetime.datetime.utcnow(),
+            )
 
-            self.public_id = str(uuid.uuid4())
-            self.username = data.get("username")
-            self.email = email
-            self.password = password
-            self.role = data.get("role", "admin")
-            self.status = data.get("status", "active")
-            self.created_at = datetime.datetime.utcnow()
-            self.updated_at = datetime.datetime.utcnow()
-            self.save()
-            return self.serialize()
+            user.save()
+            return user.serialize()
         except Exception as e:
             raise e
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -33,7 +33,7 @@ redis_cache_config = {
 }
 
 REDIS_HOST = env.str("REDIS_HOST")
-REDIS_PORT = env.int("REDIS_PORT")
+REDIS_PORT = env.str("REDIS_PORT")
 REDIS_PASSWORD = env.str("REDIS_PASSWORD")
 
 if REDIS_HOST and REDIS_PORT:


### PR DESCRIPTION
fix an issue in create review and create user endpoint where creating a new data will replace the latest added data instead of adding a new one.
the issue seems like might be related to database session and object management. when creating a new data, it will added to the session and committed to db then it will cache an 'id'. to ensure that a new object is created each time the endpoint is called, I create a new instance instead of relying solely on the 'self' object.